### PR TITLE
[openapi v3.1] Preserve property item keys

### DIFF
--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -86,22 +86,22 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                         } else {
                             // array
                             $this->_properties[$property] = [];
-                            foreach ($data[$property] as $item) {
+                            foreach ($data[$property] as $key => $item) {
                                 if ($type[0] === Type::STRING) {
                                     if (!is_string($item)) {
                                         $this->_errors[] = "property '$property' must be array of strings, but array has " . gettype($item) . " element.";
                                     }
-                                    $this->_properties[$property][] = $item;
+                                    $this->_properties[$property][$key] = $item;
                                 } elseif (Type::isScalar($type[0])) {
-                                    $this->_properties[$property][] = $item;
+                                    $this->_properties[$property][$key] = $item;
                                 } elseif ($type[0] === Type::ANY) {
                                     if (is_array($item) && isset($item['$ref'])) {
-                                        $this->_properties[$property][] = new Reference($item, null);
+                                        $this->_properties[$property][$key] = new Reference($item, null);
                                     } else {
-                                        $this->_properties[$property][] = $item;
+                                        $this->_properties[$property][$key] = $item;
                                     }
                                 } else {
-                                    $this->_properties[$property][] = $this->instantiate($type[0], $item);
+                                    $this->_properties[$property][$key] = $this->instantiate($type[0], $item);
                                 }
                             }
                         }

--- a/tests/spec/SchemaTest.php
+++ b/tests/spec/SchemaTest.php
@@ -420,4 +420,31 @@ JSON;
         $this->assertEquals('string', $person->properties['name']->type);
         $this->assertEquals('string', $person->properties['$ref']->type);
     }
+
+    public function testArrayKeyIsPerseveredInPropertiesThatAreArrays()
+    {
+        $json = <<<'JSON'
+{
+  "webhooks": {
+    "branch-protection-rule-created": {
+      "post": {
+        "description": "A branch protection rule was created.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+JSON;
+        $openApi = Reader::readFromJson($json);
+        self::assertArrayHasKey('branch-protection-rule-created', $openApi->webhooks);
+    }
 }


### PR DESCRIPTION
This is mainly useful when dealing with webhooks to use the array index as a name for the given webhook as the spec uses it as a unique identifier: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object