### PR TITLE
Zip instead of cloning and removed reference to vanished repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,10 +96,9 @@
 			"package": {
 				"name": "apis-guru/openapi-directory",
 				"version": "1.0.0",
-				"source": {
-					"url": "https://github.com/APIs-guru/openapi-directory",
-					"type": "git",
-					"reference": "openapi3.0.0"
+				"dist": {
+					"url": "https://github.com/APIs-guru/openapi-directory/archive/refs/heads/openapi3.0.0.zip",
+					"type": "zip"
 				}
 			}
 		}


### PR DESCRIPTION
The API Guru repository is very big. Using zip instead of cloning the repository makes it smaller to download and hopefully solves the CI issue in #15.

The Nexmo repository is removed and couldn't find any clone so I just removed the reference.