### PR TITLE
Support OpenAPI 3.1. ExclusiveMinimum and ExclusiveMaximum

### DIFF
--- a/src/spec/Schema.php
+++ b/src/spec/Schema.php
@@ -26,9 +26,9 @@ use cebe\openapi\SpecBaseObject;
  * @property string $title
  * @property int|float $multipleOf
  * @property int|float $maximum
- * @property bool $exclusiveMaximum
+ * @property bool|int|float $exclusiveMaximum
  * @property int|float $minimum
- * @property bool $exclusiveMinimum
+ * @property bool|int|float $exclusiveMinimum
  * @property int $maxLength
  * @property int $minLength
  * @property string $pattern (This string SHOULD be a valid regular expression, according to the [ECMA 262 regular expression dialect](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5))
@@ -75,9 +75,9 @@ class Schema extends SpecBaseObject
             'title' => Type::STRING,
             'multipleOf' => Type::NUMBER,
             'maximum' => Type::NUMBER,
-            'exclusiveMaximum' => Type::BOOLEAN,
+            // 'exclusiveMaximum' => 'boolean' for 3.0 or 'number' for 3.1, handled in constructor,
             'minimum' => Type::NUMBER,
-            'exclusiveMinimum' => Type::BOOLEAN,
+            // 'exclusiveMinimum' => 'boolean' for 3.0 or 'number' for 3.1, handled in constructor,
             'maxLength' => Type::INTEGER,
             'minLength' => Type::INTEGER,
             'pattern' => Type::STRING,
@@ -151,6 +151,15 @@ class Schema extends SpecBaseObject
                 throw new TypeErrorException(sprintf('Schema::$additionalProperties MUST be either boolean or a Schema/Reference object, "%s" given', $givenType));
             }
         }
+
+        if (isset($data['exclusiveMaximum']) && !in_array(gettype($data['exclusiveMaximum']), ['boolean', 'double', 'integer'])) {
+            throw new TypeErrorException(sprintf('Schema::$exclusiveMinimum MUST be either boolean or a number, "%s" given', gettype($data['exclusiveMaximum'])));
+        }
+
+        if (isset($data['exclusiveMinimum']) && !in_array(gettype($data['exclusiveMinimum']), ['boolean', 'double', 'integer'])) {
+            throw new TypeErrorException(sprintf('Schema::$exclusiveMinimum MUST be either boolean or a number, "%s" given', gettype($data['exclusiveMinimum'])));
+        }
+
         parent::__construct($data);
     }
 

--- a/tests/spec/SchemaTest.php
+++ b/tests/spec/SchemaTest.php
@@ -102,6 +102,20 @@ JSON
         $this->assertTrue($schema->exclusiveMaximum);
         $this->assertNull($schema->minimum);
         $this->assertNull($schema->exclusiveMinimum);
+
+        /** @var $schema Schema */
+        $schema = Reader::readFromJson('{"type": "integer", "exclusiveMaximum": 10}', Schema::class);
+        $this->assertNull($schema->maximum);
+        $this->assertSame(10, $schema->exclusiveMaximum);
+        $this->assertNull($schema->minimum);
+        $this->assertNull($schema->exclusiveMinimum);
+
+        /** @var $schema Schema */
+        $schema = Reader::readFromJson('{"type": "integer", "exclusiveMinimum": 10}', Schema::class);
+        $this->assertNull($schema->maximum);
+        $this->assertNull($schema->exclusiveMaximum);
+        $this->assertNull($schema->minimum);
+        $this->assertSame(10, $schema->exclusiveMinimum);
     }
 
     public function testReadObject()


### PR DESCRIPTION
[OpenAPI 3.0 had exclusiveMaximum and exclusiveMinimum be boolean values, following the Json schema from 2016](https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.0.4.md#schema-object).

[OpenAPI 3.1 follows the Json Schema from 2020](https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#schema-object):
[exclusiveMaximum MUST be a number](https://json-schema.org/draft/2020-12/json-schema-validation#name-exclusivemaximum)
[exclusiveMinimum MUST be a number](https://json-schema.org/draft/2020-12/json-schema-validation#name-exclusiveminimum)

To support both we need to support those values being numbers as well.

If I haven't solved it in the optimal way let me know. :+1: 

Handles part of #24 