### PR TITLE
Support 3.1 vocab for applying subschemas

### DIFF
--- a/src/spec/Schema.php
+++ b/src/spec/Schema.php
@@ -45,9 +45,19 @@ use cebe\openapi\SpecBaseObject;
  * @property Schema[]|Reference[] $oneOf
  * @property Schema[]|Reference[] $anyOf
  * @property Schema|Reference|null $not
+ * @property Schema|Reference|null $if
+ * @property Schema|Reference|null $then
+ * @property Schema|Reference|null $else
+ * @property Schema[]|Reference[]|null $dependentSchemas
+ * @property Schema[]|Reference[]|null $prefixItems
  * @property Schema|Reference|null $items
+ * @property Schema|Reference|null $contains
  * @property Schema[]|Reference[] $properties
+ * @property Schema[]|Reference[] $patternProperties
  * @property Schema|Reference|bool $additionalProperties
+ * @property Schema|Reference|null $propertyNames
+ * @property Schema|Reference|null $unevaluatedItems
+ * @property Schema|Reference|null $unevaluatedProperties
  * @property string $description
  * @property string $format
  * @property mixed $default
@@ -94,9 +104,20 @@ class Schema extends SpecBaseObject
             'oneOf' => [Schema::class],
             'anyOf' => [Schema::class],
             'not' => Schema::class,
+            'if' => Schema::class,
+            'then' => Schema::class,
+            'else' => Schema::class,
+            'dependentSchemas' => [Type::STRING, Schema::class],
+            'prefixItems' => [Schema::class],
             'items' => Schema::class,
+            'contains' => Schema::class,
             'properties' => [Type::STRING, Schema::class],
+            'patternProperties' => [Type::STRING, Schema::class],
             //'additionalProperties' => 'boolean' | ['string', Schema::class], handled in constructor
+            'propertyNames' => Schema::class,
+            'unevaluatedItems' => Schema::class,
+            //@todo add support for unevaluatedProperties
+            //'unevaluatedProperties' => Schema::class,
             'description' => Type::STRING,
             'format' => Type::STRING,
             'default' => Type::ANY,


### PR DESCRIPTION
Solve #25 

This adds support for OpenAPI 3.1 vocabulary for applying subschemas.

I believe this does not break BC because:

- [OpenAPI 3.0 only supports _custom_ keywords that are prefixed with "x-"](https://github.com/OAI/OpenAPI-Specification/blob/v3.0.4-dev/versions/3.0.4.md#specification-extensions) so no one using this library with a _valid spec_ will be using the 3.1 vocabulary.
- This library does not validate that those keywords _are not present_ in a 3.0 spec, so no functionality will be broken.

Let me know if this needs work and thank you for maintaining the library :slightly_smiling_face: 