### PR TITLE
Mark as nullable arguments with initial null value

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,6 +21,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.3"
+          - "8.4"
         dependencies:
           - "lowest"
           - "highest"
@@ -67,6 +68,8 @@ jobs:
           - php: '8.1'
             symfony-yaml: '^3.4'
           - php: '8.3'
+            symfony-yaml: '^3.4'
+          - php: '8.4'
             symfony-yaml: '^3.4'
 
     runs-on: ${{ matrix.os }}

--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -401,7 +401,7 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      * @throws exceptions\UnresolvableReferenceException in case resolving a reference fails.
      */
-    public function resolveReferences(ReferenceContext $context = null)
+    public function resolveReferences(?ReferenceContext $context = null)
     {
         // avoid recursion to get stuck in a loop
         if ($this->_recursingReferences) {

--- a/src/SpecObjectInterface.php
+++ b/src/SpecObjectInterface.php
@@ -40,7 +40,7 @@ interface SpecObjectInterface
     /**
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      */
-    public function resolveReferences(ReferenceContext $context = null);
+    public function resolveReferences(?ReferenceContext $context = null);
 
     /**
      * Set context for all Reference Objects in this object.

--- a/src/spec/Callback.php
+++ b/src/spec/Callback.php
@@ -133,7 +133,7 @@ class Callback implements SpecObjectInterface, DocumentContextInterface
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      * @throws UnresolvableReferenceException
      */
-    public function resolveReferences(ReferenceContext $context = null)
+    public function resolveReferences(?ReferenceContext $context = null)
     {
         if ($this->_pathItem !== null) {
             $this->_pathItem->resolveReferences($context);

--- a/src/spec/PathItem.php
+++ b/src/spec/PathItem.php
@@ -150,7 +150,7 @@ class PathItem extends SpecBaseObject
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      * @throws \cebe\openapi\exceptions\UnresolvableReferenceException in case resolving a reference fails.
      */
-    public function resolveReferences(ReferenceContext $context = null)
+    public function resolveReferences(?ReferenceContext $context = null)
     {
         if ($this->_ref instanceof Reference) {
             $pathItem = $this->_ref->resolve($context);

--- a/src/spec/Paths.php
+++ b/src/spec/Paths.php
@@ -246,7 +246,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      * @throws UnresolvableReferenceException
      */
-    public function resolveReferences(ReferenceContext $context = null)
+    public function resolveReferences(?ReferenceContext $context = null)
     {
         foreach ($this->_paths as $key => $path) {
             if ($path === null) {

--- a/src/spec/Reference.php
+++ b/src/spec/Reference.php
@@ -64,7 +64,7 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
      * @param string $to class name of the type referenced by this Reference
      * @throws TypeErrorException in case invalid data is supplied.
      */
-    public function __construct(array $data, string $to = null)
+    public function __construct(array $data, ?string $to = null)
     {
         if (!isset($data['$ref'])) {
             throw new TypeErrorException(
@@ -170,7 +170,7 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
      * If you call resolveReferences() make sure to replace the Reference with the resolved object first.
      * @throws UnresolvableReferenceException in case of errors.
      */
-    public function resolve(ReferenceContext $context = null)
+    public function resolve(?ReferenceContext $context = null)
     {
         if ($context === null) {
             $context = $this->getContext();
@@ -357,7 +357,7 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      * @throws UnresolvableReferenceException
      */
-    public function resolveReferences(ReferenceContext $context = null)
+    public function resolveReferences(?ReferenceContext $context = null)
     {
         throw new UnresolvableReferenceException('Cyclic reference detected, resolveReferences() called on a Reference Object.');
     }

--- a/src/spec/Responses.php
+++ b/src/spec/Responses.php
@@ -236,7 +236,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * Resolves all Reference Objects in this object and replaces them with their resolution.
      * @throws UnresolvableReferenceException
      */
-    public function resolveReferences(ReferenceContext $context = null)
+    public function resolveReferences(?ReferenceContext $context = null)
     {
         foreach ($this->_responses as $key => $response) {
             if ($response instanceof Reference) {


### PR DESCRIPTION
This PR fixes some deprecation warnings thrown with PHP 8.4 due to implicit nullability in some method arguments.

The solution involves explicitly marking them as nullable with `?string $foo = null` instead of `string $foo = null`.

See the RFC for details https://wiki.php.net/rfc/deprecate-implicitly-nullable-types 

Additionally, I also added PHP 8.4 to the php workflow, to verify deprecation warnings are not printed.