### PR TITLE
Add to gitattributes to decrease size of installed package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
-yarn.lock export-ignore
-docker-compose.yml export-ignore
-Makefile export-ignore
+/.github             export-ignore
+/schemas             export-ignore
+/tests               export-ignore
+.gitattributes       export-ignore
+.gitignore           export-ignore
+.php_cs.dist         export-ignore
+docker-compose.yml   export-ignore
+Makefile             export-ignore
+phpunit.xml.dist     export-ignore
+phpunit11.xml.dist   export-ignore
+yarn.lock           export-ignore


### PR DESCRIPTION
This should reduce the size of this package when downloaded to vendor directories. 

I don't think that any of these files are required for this package to be used.

(was inspired after having a look through a vendor directory and having a read of  https://php.watch/articles/composer-gitattributes )