### PR TITLE
Support OpenAPI 3.1 const keyword

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,12 @@ install: composer.lock yarn.lock
 	$(DOCKER_PHP) composer install --prefer-dist --no-interaction --no-progress --ansi
 	$(DOCKER_NODE) yarn install
 
-test: unit test-recursion.json test-recursion2.yaml test-recursion3_index.yaml test-empty-maps.json
+test: unit test-recursion.json test-recursion2.yaml test-recursion3_index.yaml test-empty-maps.json const.json
 
 unit:
 	$(DOCKER_PHP) php $(PHPARGS) $(XPHPARGS) vendor/bin/phpunit --verbose --colors=always $(TESTCASE)
 
-test-debug: unit-debug test-recursion.json test-recursion2.yaml test-recursion3_index.yaml test-empty-maps.json
+test-debug: unit-debug test-recursion.json test-recursion2.yaml test-recursion3_index.yaml test-empty-maps.json const.json
 
 unit-debug:
 	$(DOCKER_PHP) php $(PHPARGS) $(XPHPARGS) vendor/bin/phpunit --debug --testdox --colors=always -c phpunit11.xml.dist $(TESTCASE)
@@ -61,6 +61,7 @@ lint: install
 	$(DOCKER_PHP) php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/recursion.json
 	$(DOCKER_PHP) php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/recursion2.yaml
 	$(DOCKER_PHP) php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/empty-maps.json
+	$(DOCKER_PHP) php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/const.json
 	$(DOCKER_NODE) yarn run speccy lint tests/spec/data/reference/playlist.json
 	$(DOCKER_NODE) yarn run speccy lint tests/spec/data/recursion.json
 

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
 				"source": {
 					"url": "https://github.com/OAI/OpenAPI-Specification",
 					"type": "git",
-					"reference": "v3.1.1-dev"
+					"reference": "3.1.1"
 				}
 			}
 		},

--- a/src/spec/Schema.php
+++ b/src/spec/Schema.php
@@ -39,6 +39,7 @@ use cebe\openapi\SpecBaseObject;
  * @property int $minProperties
  * @property string[] $required list of required properties
  * @property array $enum
+ * @property mixed $const
  *
  * @property string|string[] $type type can only be `string` in OpenAPI 3.0, but can be an array of strings since OpenAPI 3.1
  * @property Schema[]|Reference[] $allOf
@@ -88,6 +89,8 @@ class Schema extends SpecBaseObject
             'minProperties' => Type::INTEGER,
             'required' => [Type::STRING],
             'enum' => [Type::ANY],
+            // Added in 3.1: https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01#name-const
+            'const' => Type::ANY,
             // The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
             'type' => Type::STRING,
             'allOf' => [Schema::class],
@@ -121,6 +124,7 @@ class Schema extends SpecBaseObject
             'additionalProperties' => true,
             'required' => null,
             'enum' => null,
+            'const' => null,
             'allOf' => null,
             'oneOf' => null,
             'anyOf' => null,

--- a/tests/spec/OpenApiTest.php
+++ b/tests/spec/OpenApiTest.php
@@ -149,6 +149,11 @@ class OpenApiTest extends \PHPUnit\Framework\TestCase
 
         // examples from https://github.com/APIs-guru/openapi-directory/tree/openapi3.0.0/APIs
         $apisGuruExamples = [];
+
+        $localExamples = [
+            __DIR__ . '/data/const.json',
+        ];
+
         /** @var $it RecursiveDirectoryIterator|RecursiveIteratorIterator */
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(__DIR__ . '/../../vendor/apis-guru/openapi-directory/APIs'));
         $it->rewind();
@@ -177,7 +182,8 @@ class OpenApiTest extends \PHPUnit\Framework\TestCase
             $oaiExamples,
             $mermadeExamples,
             $apisGuruExamples,
-            $nexmoExamples
+            $nexmoExamples,
+            $localExamples
         );
         foreach($all as $path) {
             yield $path => [

--- a/tests/spec/SchemaTest.php
+++ b/tests/spec/SchemaTest.php
@@ -335,6 +335,7 @@ JSON;
             'maxProperties' => null,
             'minProperties' => null,
             'required' => null, // if set, it should not be an empty array, according to the spec
+            'const' => null,
             'enum' => null, // if it is an array, it means restriction of values
             // The following properties are taken from the JSON Schema definition but their definitions were adjusted to the OpenAPI Specification.
             'type' => null,

--- a/tests/spec/data/const.json
+++ b/tests/spec/data/const.json
@@ -1,0 +1,35 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "test",
+    "version": "1.0",
+    "contact": {
+      "email": "somebody@example.com"
+    }
+  },
+  "components": {
+    "schemas": {
+      "Product": {
+        "title": "Product",
+        "description": "A product.",
+        "type": "object",
+        "properties": {
+          "color": {
+            "oneOf": [
+              {
+                "const": "RGB",
+                "title": "Red, Green, Blue",
+                "description": "Specify colors with the red, green, and blue additive color model"
+              },
+              {
+                "const": "CMYK",
+                "title": "Cyan, Magenta, Yellow, Black",
+                "description": "Specify colors with the cyan, magenta, yellow, and black subtractive color model"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
See:
- Example: https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#model-with-annotated-enumeration
- Spec: https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01#name-const